### PR TITLE
Do not install kubectl-crossplane if already exists

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: composite
   steps: 
-    - run: curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh
+    - run: "[ -f kubectl-crossplane ] || curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh"
       shell: bash
     - run: "./kubectl-crossplane ${{ inputs.command }}"
       shell: bash


### PR DESCRIPTION
Updates action to only download the binary once if it is run multiple
times consecutively.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>