### PR TITLE
Allow specifying channel and release in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,16 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: release channel
+        required: true
+        default: stable
+      version:
+        description: release version
+        required: true
+        default: current
 
 env:
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
@@ -27,6 +36,8 @@ jobs:
       - name: Build xpkg
         uses: crossplane-contrib/xpkg-action@master
         with:
+          channel: ${{ github.events.inputs.channel }}
+          version: ${{ github.events.inputs.version }}
           command: build configuration -f test/xpkg-action-test --name=xpkg-action-test
       - name: Push xpkg
         uses: crossplane-contrib/xpkg-action@master


### PR DESCRIPTION
Updates test workflow to specify channel and release. Will use default
of the action on pushes where inputs are not specified.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>