### PR TITLE
Use workflow version input for action version input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         uses: crossplane-contrib/xpkg-action@master
         with:
           channel: ${{ github.event.inputs.channel }}
-          version: ${{ github.event.inputs.channel }}
+          version: ${{ github.event.inputs.version }}
           command: build configuration -f test/xpkg-action-test --name=xpkg-action-test
       - name: Push xpkg
         uses: crossplane-contrib/xpkg-action@master


### PR DESCRIPTION
Fixes using channel input for version.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>