### PR TITLE
fix: move to crossplane instead of kubectl-crossplane

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,10 @@ inputs:
 runs:
   using: composite
   steps: 
-    - run: "[ -f kubectl-crossplane ] || curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh"
+    - run: "[ -f crossplane ] || curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh"
       shell: bash
       env:
         CHANNEL: ${{ inputs.channel }}
         VERSION: ${{ inputs.version }}
-    - run: "./kubectl-crossplane ${{ inputs.command }}"
+    - run: "./crossplane ${{ inputs.command }}"
       shell: bash


### PR DESCRIPTION
Required due to https://github.com/crossplane/docs/pull/562