### PR TITLE
update github runner image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The test build is currently stalled in this repo. 
![Screen Shot 2023-10-20 at 9 52 16 AM](https://github.com/crossplane-contrib/xpkg-action/assets/9144708/f7a49b69-93eb-4201-bbac-ed62ece0b9c7)

GitHub deprecated Ubuntu 18.04 and stopped supporting it earlier this year.  [The Ubuntu 18.04 Actions runner image will begin deprecation on 2022/08/08 and will be fully unsupported by 2023/04/03 #6002 ](https://github.com/actions/runner-images/issues/6002)