### PR TITLE
Update Crossplane CLI install script variable names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
     - run: "[ -f crossplane ] || curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh"
       shell: bash
       env:
-        CHANNEL: ${{ inputs.channel }}
-        VERSION: ${{ inputs.version }}
+        XP_CHANNEL: ${{ inputs.channel }}
+        XP_VERSION: ${{ inputs.version }}
     - run: "./crossplane ${{ inputs.command }}"
       shell: bash


### PR DESCRIPTION
This PR just merges the work already done in https://github.com/upbound/xpkg-action/pull/1, to update the env var names used in this action to match what's used in the Crossplane CLI install script: https://github.com/crossplane/crossplane/blob/main/install.sh#L5-L6

This action is still in use in https://github.com/crossplane/conformance and needs updating to get https://github.com/crossplane/conformance/pull/31 succeeding.